### PR TITLE
Fixed reset database permissions and test-side timeout config

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -244,6 +244,10 @@ Resources:
             Resource: !Sub
               - arn:${AWS::Partition}:neptune-db:${AWS::Region}:${AWS::AccountId}:${ClusterId}/*
               - ClusterId: !GetAtt PheBeeNeptuneCluster.ClusterResourceId
+          - Effect: Allow
+            Action:
+              - rds:DescribeDBClusters
+            Resource: !Sub arn:${AWS::Partition}:rds:${AWS::Region}:${AWS::AccountId}:cluster:${AWS::StackName}-neptune-cluster
   
   PheBeeNeptuneLoadPolicy:
     Type: AWS::IAM::ManagedPolicy
@@ -695,6 +699,7 @@ Resources:
       CodeUri: functions
       Handler: reset_database.lambda_handler
       MemorySize: 512
+      Timeout: 300
       Environment:
         Variables:
           NeptuneEndpoint: !Sub https://${PheBeeNeptuneCluster.Endpoint}:${PheBeeNeptuneCluster.Port}
@@ -709,6 +714,7 @@ Resources:
           - !Ref SubnetId2
       Policies:
         - !Ref PheBeeNeptuneResetPolicy
+        - !Ref PheBeeNeptuneReadPolicy
         - !Ref PheBeeDynamoDBWritePolicy
         - !Ref PheBeeDynamoDBReadPolicy
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -5,6 +5,7 @@ import boto3
 import uuid
 import json
 from botocore.exceptions import ClientError
+from botocore.config import Config
 from requests_aws4auth import AWS4Auth
 
 from phebee.utils.aws import get_client
@@ -37,11 +38,13 @@ def aws_session(request, profile_name):
     # Create a client for each service, so that they are ready to use.
     # If any other clients are needed, add them here so they are instantiated as well.
     get_client("s3", profile_name)
-    get_client("lambda", profile_name)
     get_client("cloudformation", profile_name)
     get_client("stepfunctions", profile_name)
     get_client("dynamodb", profile_name)
 
+    lambda_config = Config(read_timeout=900, connect_timeout=900, retries={"max_attempts": 0})
+    get_client("lambda", profile_name, lambda_config)
+    
     session = boto3.Session(profile_name=profile_name)
 
     return session

--- a/tests/integration/test_reset_database.py
+++ b/tests/integration/test_reset_database.py
@@ -6,8 +6,7 @@ from phebee.utils.aws import get_client
 
 
 def reset_database(cloudformation_stack):
-    config = Config(read_timeout=900, connect_timeout=900, retries={"max_attempts": 0})
-    lambda_client = get_client("lambda", config=config)
+    lambda_client = get_client("lambda")
 
     reset_database_lambda_arn = get_output_value_from_stack(
         cloudformation_stack, "ResetDatabaseFunctionArn"


### PR DESCRIPTION
Added rds:DescribeDBClusters permission to PheBeeNeptuneReadPolicy
Added PheBeeNeptuneReadPolicy to ResetDatabaseFunction permissions
Fixed bug in test_reset_database.py in which increased client-side lambda timeout was not being used due to boto3 client caching.  Instead, a 15 minute timeout is now in place for the cached lambda client in all tests.